### PR TITLE
Python version changed in Pipfile and Pipfile.lock 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ pytest-django = "*"
 vmck = {editable = true,path = "."}
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6"
         },
         "sources": [
             {


### PR DESCRIPTION
The version of python was modified in Pipfile and Pipfile.lock from 3.7 to 3.6. The "pipenv sync" command is not modifying the version of the python from Pipfile.lock.